### PR TITLE
Add phantomJS options and fix exit

### DIFF
--- a/src/commands/test/util/browser-tests-runner/index.js
+++ b/src/commands/test/util/browser-tests-runner/index.js
@@ -59,9 +59,9 @@ function startServer(tests, options, devTools) {
             },
             devTools.config.browserBuilder || {});
 
-        if(shouldCover) {
+        if (shouldCover) {
             browserBuilderConfig.plugins.push(
-                require('./lasso-istanbul-plugin')
+                require('./lasso-istanbul-plugin')(devTools.config.istanbulLibInstrumentOptions)
             );
         }
 


### PR DESCRIPTION
This makes phantomJS and istanbul-lib-instrument configurable from `.marko-devtools.js`. 

```js
module.exports = function(markoDevtools) {
    markoDevtools.configure({
        istanbulLibInstrumentOptions: {
            esModules: true
        },
        phantomOptions: {
            useColors: true,
            ignoreResourceErrors: true,
            viewportSize: {
                width: 1280,
                height: 1024
            }
        }
    });
};
```

Also, it seems only with browser tests, mochaphantomjs was not exiting properly (either on success or failure. `then` and `catch` are being executed properly and the server closed, but the process just hangs. This is one area I wouldn't mind discuss more as I'm not sure if this is expected or not with mochaphantomjs. (I'd expect it to work out of the box) 

However, manually exiting the process makes the tests work as expected. I'll make some comments inline.