### PR TITLE
Allow shared dependencies to be specified from marko-devtools.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ For example, shared test dependencies can be specified with the `dependencies` o
 
 ```javascript
 module.exports = function(markoDevTools) {
-    markoDevTools.config.dependencies = [
+    markoDevTools.config.browserTestDependencies = [
         'bluebird/js/browser/bluebird.core.js',
         'require-run: ./tools/myDependency.js',
     ];

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ module.exports = function(markoDevTools) {
 }
 ```
 
-You can provide a package-specific plugin by creating a `.marko-devtools.js` file at the root of your project:
+You can provide a package-specific plugin by creating a `marko-devtools.js` file at the root of your project:
 
 _my-app/.marko-devtools.js:_
 
@@ -201,6 +201,41 @@ module.exports = function(markoDevTools) {
 ```
 
 A package-specific plugin will automatically be loaded when `marko` is launched.
+
+Some options can be specified on the `config` object that `markoDevTools` exposes.
+
+For example, shared test dependencies can be specified with the `dependencies` option.
+
+```javascript
+module.exports = function(markoDevTools) {
+    markoDevTools.config.dependencies = [
+        'bluebird/js/browser/bluebird.core.js',
+        'require-run: ./tools/myDependency.js',
+    ];
+}
+```
+
+For more info on how to specify dependencies can be found [here](https://github.com/lasso-js/lasso#dependencies).
+
+Lasso plugins and transforms can also be specified using the `browserBuilder` option.
+
+```javascript
+module.exports = function(markoDevTools) {
+    markoDevTools.config.browserBuilder = {
+        plugins: [
+            'lasso-marko',
+            'lasso-less'
+        ],
+        require: {
+           transforms: [
+               {
+                   transform: 'lasso-babel-transform'
+               }
+           ]
+        }
+    };
+}
+```
 
 # TODO
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "istanbul-lib-instrument": "^1.4.2",
     "lasso": "*",
     "lasso-package-root": "^1.0.0",
+    "lasso-require": "^3.4.1",
     "lasso-resolve-from": "^1.2.0",
     "marko": "*",
     "mkdirp": "^0.5.1",

--- a/src/commands/test/util/browser-tests-runner/index.js
+++ b/src/commands/test/util/browser-tests-runner/index.js
@@ -111,12 +111,12 @@ function startServer(tests, options, devTools) {
             "require-run: " + require.resolve('./setup')
         ];
 
-        var configDependencies = devTools.config.dependencies;
+        var browserTestDependencies = devTools.config.browserTestDependencies;
 
-        if (configDependencies) {
-            if (Array.isArray(configDependencies)) {
+        if (browserTestDependencies) {
+            if (Array.isArray(browserTestDependencies)) {
                 // load in any dependencies (if specified)
-                configDependencies.forEach(function (dependency) {
+                browserTestDependencies.forEach(function (dependency) {
                     // resolve paths based on the project's directory
                     if ((typeof dependency === 'string' || dependency instanceof String)) {
                         var parsedDependency = parseRequire(dependency);

--- a/src/commands/test/util/browser-tests-runner/index.js
+++ b/src/commands/test/util/browser-tests-runner/index.js
@@ -117,16 +117,19 @@ function startServer(tests, options, devTools) {
             if (Array.isArray(configDependencies)) {
                 // load in any dependencies (if specified)
                 configDependencies.forEach(function (dependency) {
-                    var parsedDependency = parseRequire(dependency);
-                    var type = parsedDependency.type;
+                    // resolve paths based on the project's directory
+                    if ((typeof dependency === 'string' || dependency instanceof String)) {
+                        var parsedDependency = parseRequire(dependency);
+                        var type = parsedDependency.type;
+                        var path = resolveFrom(devTools.cwd, parsedDependency.path);
 
-                    // resolve the path from the project directory
-                    var path = resolveFrom(devTools.cwd, parsedDependency.path);
-
-                    if (type) {
-                        dependency = type + ': ' + path;
-                    } else {
-                        dependency = path;
+                        if (type) {
+                            dependency = type + ': ' + path;
+                        } else {
+                            dependency = path;
+                        }
+                    } else if ((path = dependency.path)) {
+                        dependency.path = resolveFrom(devTools.cwd, path);
                     }
 
                     browserDependencies.push(dependency);


### PR DESCRIPTION
Since having copies of a `browser.json` in every component directory is rather annoying I figured it would be nice to have the option to specify any shared dependencies on the `config` object within the project's `marko-devtools.js`.